### PR TITLE
Use new source/trigger header format for Chrome versions >= 104

### DIFF
--- a/conversion-measurement/package.json
+++ b/conversion-measurement/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "structured-headers": "^0.4.1"
+  }
+}


### PR DESCRIPTION
- The Attribution-Reporting-Register-Aggregatable-Source header is
  replaced with a new "aggregation_keys" field in the
  Attribution-Reporting-Register-Source header.
  - The list is replaced with a dictionary.
- The various trigger headers were consolidated into a single one.

https://github.com/WICG/attribution-reporting-api/pull/434
https://github.com/WICG/attribution-reporting-api/pull/441
https://github.com/WICG/attribution-reporting-api/pull/443