### PR TITLE
Migrate to valueless attributionsrc, use meaningful aggregation keys, and remove conditional header format

### DIFF
--- a/conversion-measurement/functions/apps/adtech.js
+++ b/conversion-measurement/functions/apps/adtech.js
@@ -20,23 +20,8 @@ const cookieParser = require('cookie-parser')
 require('dotenv').config({ path: `.env.${process.env.NODE_ENV}` })
 const path = require('path')
 const { createHash } = require('node:crypto')
-const structuredHeaders = require('structured-headers')
 
 const adtech = express()
-
-const useOldHeaders = (req) => {
-  const ua = req.get('Sec-CH-UA')
-  try {
-    return structuredHeaders.parseList(ua).some((item) => {
-      return (
-        ['Google Chrome', 'Chromium'].includes(item[0]) &&
-        Number.parseFloat(item[1].get('v')) < 104
-      )
-    })
-  } catch {
-    return false
-  }
-}
 
 adtech.use(express.json())
 adtech.use(cookieParser())
@@ -184,15 +169,6 @@ adtech.get(['/register-source', '/shoes'], (req, res) => {
       key_purchaseValue: generateSourceKeyPiece('VALUE, CampaignID=12, GeoID=7')
     }
   }
-
-  const aggregatableId1 = 'key_purchaseCount'
-  const aggregatableId2 = 'key_purchaseValue'
-  const aggregatableKeyPiece1 = generateSourceKeyPiece(
-    'COUNT, CampaignID=12, GeoID=7'
-  )
-  const aggregatableKeyPiece2 = generateSourceKeyPiece(
-    'VALUE, CampaignID=12, GeoID=7'
-  )
 
   // Send a response with the header Attribution-Reporting-Register-Source in order to instruct the browser to register a source event
   res.set('Attribution-Reporting-Register-Source', JSON.stringify(headerConfig))

--- a/conversion-measurement/functions/apps/adtech.js
+++ b/conversion-measurement/functions/apps/adtech.js
@@ -162,12 +162,8 @@ adtech.get(
         conversion_product_type: ['category_1']
       },
       aggregation_keys: {
-        key_purchaseCount: generateSourceKeyPiece(
-          'COUNT, CampaignID=12, GeoID=7'
-        ),
-        key_purchaseValue: generateSourceKeyPiece(
-          'VALUE, CampaignID=12, GeoID=7'
-        )
+        purchaseCount: generateSourceKeyPiece('COUNT, CampaignID=12, GeoID=7'),
+        purchaseValue: generateSourceKeyPiece('VALUE, CampaignID=12, GeoID=7')
       }
     }
 
@@ -260,13 +256,13 @@ adtech.get('/conversion', (req, res) => {
     {
       key_piece: generateTriggerKeyPiece(`ProductCategory=${productCategory}`),
       // Apply this key piece to:
-      source_keys: ['key_purchaseCount', 'key_purchaseValue']
+      source_keys: ['purchaseCount', 'purchaseValue']
     }
   ]
 
   const aggregatableValues = {
-    key_purchaseCount: 1 * SCALING_FACTOR_PURCHASE_COUNT,
-    key_purchaseValue: parseInt(purchaseValue) * SCALING_FACTOR_PURCHASE_VALUE
+    purchaseCount: 1 * SCALING_FACTOR_PURCHASE_COUNT,
+    purchaseValue: parseInt(purchaseValue) * SCALING_FACTOR_PURCHASE_VALUE
   }
 
   // Debug report (common to event-level and aggregate)

--- a/conversion-measurement/functions/apps/advertiser.js
+++ b/conversion-measurement/functions/apps/advertiser.js
@@ -132,12 +132,12 @@ advertiser.get('/checkout', (req, res) => {
   if (!req.session.purchaseId) {
     req.session.purchaseId = Math.floor(Math.random() * 100000)
   }
-  const conversionType = 'checkout-completed'
   const { prio, dedup, purchaseId } = req.session
 
   const searchParams = new URLSearchParams({
-    'conversion-type': 'signup-newsletter',
+    'conversion-type': 'checkout-completed',
     'product-category': 'category_1',
+    'purchase-value': 200,
     'prio-checkout': prio,
     dedup: dedup,
     'purchase-id': purchaseId

--- a/conversion-measurement/functions/package.json
+++ b/conversion-measurement/functions/package.json
@@ -25,8 +25,7 @@
     "firebase-admin": "^10.0.2",
     "firebase-functions": "^3.21.2",
     "pug": "^3.0.0",
-    "request": "^2.88.2",
-    "structured-headers": "^0.4.1"
+    "request": "^2.88.2"
   },
   "private": true
 }

--- a/conversion-measurement/functions/views/adtech/ad-click-js.pug
+++ b/conversion-measurement/functions/views/adtech/ad-click-js.pug
@@ -7,7 +7,7 @@ body(style={"font-family": "sans-serif", "background": "#f6d7ff"})
 
 div (JS method will be called on click)
   p
-  div(id="ad" style="cursor:pointer; text-decoration:underline;") Click me
+  div(id="ad" style="cursor:pointer; color: blue; text-decoration:underline;") Click me
   
 script.
   // \!{}\ is the syntax for this template engine (pug) to access server-defined variables in a script

--- a/conversion-measurement/functions/views/adtech/ad-click.pug
+++ b/conversion-measurement/functions/views/adtech/ad-click.pug
@@ -9,5 +9,5 @@ div Ad (
   code a
   |  element):
 br
-a(href=href alt='blue shoes' attributionsrc=attributionsrc target="_blank") Click me
+a(href="/register-source-href" alt='blue shoes' attributionsrc target="_blank") Click me
 

--- a/conversion-measurement/functions/views/adtech/ad-click.pug
+++ b/conversion-measurement/functions/views/adtech/ad-click.pug
@@ -9,5 +9,5 @@ div Ad (
   code a
   |  element):
 br
-a(href=href src='/blue-shoes.png' alt='blue shoes' attributionsrc=attributionsrc target="_blank") Click me
+a(href=href alt='blue shoes' attributionsrc=attributionsrc target="_blank") Click me
 

--- a/conversion-measurement/functions/views/adtech/ad-click.pug
+++ b/conversion-measurement/functions/views/adtech/ad-click.pug
@@ -9,5 +9,5 @@ div Ad (
   code a
   |  element):
 br
-a(href="/register-source-href" alt='blue shoes' attributionsrc target="_blank") Click me
+a(href='/register-source-href' alt='blue shoes' attributionsrc target='_blank') Click me
 

--- a/conversion-measurement/functions/views/adtech/ad-view-img.pug
+++ b/conversion-measurement/functions/views/adtech/ad-view-img.pug
@@ -9,4 +9,4 @@ div Ad (
   code img
   |  element):
 
-img(width='180' href=href src='/shoes' alt='blue shoes' attributionsrc)
+img(width='180' src='/register-source-image' alt='blue shoes' attributionsrc)

--- a/conversion-measurement/functions/views/adtech/ad-view-img.pug
+++ b/conversion-measurement/functions/views/adtech/ad-view-img.pug
@@ -9,4 +9,4 @@ div Ad (
   code img
   |  element):
 
-img(width='180' href=href src='/blue-shoes.png' alt='blue shoes' attributionsrc=attributionsrc)
+img(width='180' href=href src='/shoes' alt='blue shoes' attributionsrc)

--- a/conversion-measurement/functions/views/advertiser/_layout.pug
+++ b/conversion-measurement/functions/views/advertiser/_layout.pug
@@ -22,38 +22,41 @@ html
                     div
                         strong Choose a way to convert:
                         div.conversion-list
-                            div
+                            div.conversion-list-section-1
                                 div 
-                                    a(href='/blue-shoes') Visit product page: shoes 
+                                    a(href='/blue-shoes') Visit product page: shoes* 
                                     div.trigger
                                         code trigger_data=3 (clicks)
                                         br
                                         code trigger_data=0 (views)
                                 div 
-                                    a(href='/add-to-cart') Add product to cart
+                                    a(href='/add-to-cart') Add product to cart*
                                     div.trigger
                                         code trigger_data=2 (clicks)
                                         br
                                         code trigger_data=0 (views)
                                 div 
-                                    a(href='/checkout' class='checkout') Complete checkout 💰
+                                    a(href='/checkout' class='checkout') Complete checkout**
                                     div.trigger
                                         code trigger_data=1 (clicks)
                                         br
                                         code trigger_data=1 (views)
-                            div
+                            div.conversion-list-section-2
                                 div 
-                                    a(href='/signup-newsletter') Sign up for special offers
+                                    a(href='/signup-newsletter') Sign up for special offers*
                                     div.trigger
                                         code trigger_data=4 (clicks)
                                         br
                                         code trigger_data=0 (views)
                                 div 
-                                    a(href='/t-shirt') Visit product page: T-Shirt 
+                                    a(href='/t-shirt') Visit product page: T-Shirt* 
                                     div.trigger
                                         code trigger_data=3 (clicks)
                                         br
                                         code trigger_data=0 (views)
+                                div 
+                                    div * = We've set up this conversion to generate event-level reports only.
+                                    div ** = We've set up this conversion to generate event-level reports AND aggregatable reports.
                     div 
                         a#settings(href='/settings') Demo Settings ⚙️ 
     div.main.mainContentWrapper

--- a/conversion-measurement/functions/views/advertiser/add-to-cart.pug
+++ b/conversion-measurement/functions/views/advertiser/add-to-cart.pug
@@ -2,6 +2,6 @@ extends _layout.pug
 
 block content
     h3 Product added to cart 
-    img.pixel(height='12' width='12' src=adtechRequestUrl)
+    img.pixel(height='12' width='12' attributionsrc src=adtechRequestUrl)
     div.pixel-name Pixel that tracks when a product is added to the cart
     script(src="./toast.js")

--- a/conversion-measurement/functions/views/advertiser/add-to-cart.pug
+++ b/conversion-measurement/functions/views/advertiser/add-to-cart.pug
@@ -2,6 +2,6 @@ extends _layout.pug
 
 block content
     h3 Product added to cart 
-    img.pixel(height='12' width='12' attributionsrc=adtechRequestUrl)
+    img.pixel(height='12' width='12' src=adtechRequestUrl)
     div.pixel-name Pixel that tracks when a product is added to the cart
     script(src="./toast.js")

--- a/conversion-measurement/functions/views/advertiser/blue-shoes.pug
+++ b/conversion-measurement/functions/views/advertiser/blue-shoes.pug
@@ -11,6 +11,6 @@ block content
                 div Sport: Running
                 div Shoe tip: Round
         div
-            img.pixel(height='12' width='12' src=adtechRequestUrl)
+            img.pixel(height='12' width='12' attributionsrc src=adtechRequestUrl)
             div.pixel-name Pixel that tracks product page visits
     script(src="./toast.js")

--- a/conversion-measurement/functions/views/advertiser/blue-shoes.pug
+++ b/conversion-measurement/functions/views/advertiser/blue-shoes.pug
@@ -11,6 +11,6 @@ block content
                 div Sport: Running
                 div Shoe tip: Round
         div
-            img.pixel(height='12' width='12' attributionsrc=adtechRequestUrl)
+            img.pixel(height='12' width='12' src=adtechRequestUrl)
             div.pixel-name Pixel that tracks product page visits
     script(src="./toast.js")

--- a/conversion-measurement/functions/views/advertiser/checkout.pug
+++ b/conversion-measurement/functions/views/advertiser/checkout.pug
@@ -2,7 +2,7 @@ extends _layout.pug
 
 block content
     h3 Thanks for your purchase!
-    img.pixel(height='12' width='12' attributionsrc=adtechRequestUrl)
+    img.pixel(height='12' width='12' src=adtechRequestUrl)
     div.pixel-name Pixel that tracks purchases (completed checkouts)
     div  Order ID: #{purchaseId}
     button(onClick="generateNewPurchase()") 🔄 New purchase (buy something else)

--- a/conversion-measurement/functions/views/advertiser/checkout.pug
+++ b/conversion-measurement/functions/views/advertiser/checkout.pug
@@ -2,7 +2,7 @@ extends _layout.pug
 
 block content
     h3 Thanks for your purchase!
-    img.pixel(height='12' width='12' src=adtechRequestUrl)
+    img.pixel(height='12' width='12' attributionsrc src=adtechRequestUrl)
     div.pixel-name Pixel that tracks purchases (completed checkouts)
     div  Order ID: #{purchaseId}
     button(onClick="generateNewPurchase()") 🔄 New purchase (buy something else)

--- a/conversion-measurement/functions/views/advertiser/signup-newsletter.pug
+++ b/conversion-measurement/functions/views/advertiser/signup-newsletter.pug
@@ -2,6 +2,6 @@ extends _layout.pug
 
 block content
     h3 You're now signed up to our special offers newsletter
-    img.pixel(height='12' width='12' src=adtechRequestUrl)
+    img.pixel(height='12' width='12' attributionsrc src=adtechRequestUrl)
     div.pixel-name Pixel that tracks newsletter signups
     script(src="./toast.js")

--- a/conversion-measurement/functions/views/advertiser/signup-newsletter.pug
+++ b/conversion-measurement/functions/views/advertiser/signup-newsletter.pug
@@ -2,6 +2,6 @@ extends _layout.pug
 
 block content
     h3 You're now signed up to our special offers newsletter
-    img.pixel(height='12' width='12' attributionsrc=adtechRequestUrl)
+    img.pixel(height='12' width='12' src=adtechRequestUrl)
     div.pixel-name Pixel that tracks newsletter signups
     script(src="./toast.js")

--- a/conversion-measurement/functions/views/advertiser/t-shirt.pug
+++ b/conversion-measurement/functions/views/advertiser/t-shirt.pug
@@ -11,6 +11,6 @@ block content
                 div Pattern: Plain
                 div Length: Normal
         div
-            img.pixel(height='12' width='12' src=adtechRequestUrl)
+            img.pixel(height='12' width='12' attributionsrc src=adtechRequestUrl)
             div.pixel-name Pixel that tracks product page visits. A report for this conversion will be generated but will NOT be sent, due to filters: the adtech server is filtering out conversions for the product category 'category_2' (T-Shirts)
     script(src="./toast.js")

--- a/conversion-measurement/functions/views/advertiser/t-shirt.pug
+++ b/conversion-measurement/functions/views/advertiser/t-shirt.pug
@@ -11,6 +11,6 @@ block content
                 div Pattern: Plain
                 div Length: Normal
         div
-            img.pixel(height='12' width='12' attributionsrc=adtechRequestUrl)
+            img.pixel(height='12' width='12' src=adtechRequestUrl)
             div.pixel-name Pixel that tracks product page visits. A report for this conversion will be generated but will NOT be sent, due to filters: the adtech server is filtering out conversions for the product category 'category_2' (T-Shirts)
     script(src="./toast.js")

--- a/conversion-measurement/sites/advertiser/styles.css
+++ b/conversion-measurement/sites/advertiser/styles.css
@@ -106,6 +106,14 @@ code {
   display: flex;
 }
 
+.conversion-list-section-1 {
+  flex: 8;
+}
+
+.conversion-list-section-2 {
+  flex: 7;
+}
+
 .conversion-list > div > div {
   margin: 0.6rem 1rem 0.6rem 0;
 }

--- a/conversion-measurement/sites/advertiser/toast.js
+++ b/conversion-measurement/sites/advertiser/toast.js
@@ -16,7 +16,7 @@
 
 if (document.featurePolicy.allowsFeature('attribution-reporting')) {
   Toastify({
-    text: `💡 Demo tip: \n\n The conversion pixel makes a request to the adtech endpoint (attributionsrc). \n The adtech endpoint then instructs the browser to trigger an attribution. \n If the browser finds a source event that matches this trigger, it generates an attribution report. \n\n You can see the report in chrome://attribution-internals.\n`,
+    text: `💡 Demo tip: \n\n The conversion pixel makes a request to the adtech endpoint. \n The adtech endpoint then instructs the browser to trigger an attribution. \n If the browser finds a source event that matches this trigger, it generates an attribution report. \n\n You can see the report in chrome://attribution-internals.\n`,
     duration: -1, // infinity
     close: true,
     gravity: 'top',


### PR DESCRIPTION
* Use the new attributionsrc
* Replace trigger side attributionsrc
* Use the same agg keys as for the OH (and hashing helper functions, and query params)
* Remove conditional header format based on browser version